### PR TITLE
deploy: always sign with PRIVATE_KEY (never PRIVATE_KEY_DEV)

### DIFF
--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -22,7 +22,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      DEPLOYMENT_KEY: ${{ github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV }}
+      DEPLOYMENT_KEY: ${{ secrets.PRIVATE_KEY }}
     steps:
       - run: |
           network=${{ inputs.network }}
@@ -54,7 +54,7 @@ jobs:
         run: nix develop -c rainix-sol-artifacts
         env:
           DEPLOY_BROADCAST: '1'
-          DEPLOYMENT_KEY: ${{ github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV }}
+          DEPLOYMENT_KEY: ${{ secrets.PRIVATE_KEY }}
           ETH_RPC_URL: ${{ secrets[env.rpc_secret_name] || vars[env.rpc_secret_name] || '' }}
           ETHERSCAN_API_KEY: ${{ secrets[env.etherscan_api_key_secret_name] || vars[env.etherscan_api_key_secret_name] || ''}}
           DEPLOY_VERIFY: ${{ secrets[env.verify_secret_name] || vars[env.verify_secret_name] || '' }}

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
-      DEPLOYMENT_KEY: ${{ github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV }}
+      DEPLOYMENT_KEY: ${{ secrets.PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -44,8 +44,8 @@ jobs:
           CI_FORK_SEPOLIA_DEPLOYER_ADDRESS: ${{ vars.CI_FORK_SEPOLIA_DEPLOYER_ADDRESS }}
           CI_DEPLOY_SEPOLIA_RPC_URL: ${{ secrets.CI_DEPLOY_SEPOLIA_RPC_URL || vars.CI_DEPLOY_SEPOLIA_RPC_URL }}
           RPC_URL_ETHEREUM_FORK: ${{ secrets.RPC_URL_ETHEREUM_FORK }}
-          RPC_URL_POLYGON_FORK: ${{ secrets.CI_DEPLOY_POLYGON_RPC_URL || vars.CI_DEPLOY_POLYGON_RPC_URL || '' }}
-          RPC_URL_BSC_FORK: ${{ secrets.CI_DEPLOY_BSC_RPC_URL || vars.CI_DEPLOY_BSC_RPC_URL || '' }}
+          RPC_URL_POLYGON_FORK: ${{ secrets.RPC_URL_POLYGON_FORK }}
+          RPC_URL_BSC_FORK: ${{ secrets.RPC_URL_BSC_FORK || secrets.CI_DEPLOY_BSC_RPC_URL }}
           UNI_V2_FACTORY: '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
           UNI_V3_FACTORY: '0x1F98431c8aD98523631AE4a59f267346ea31F984'
         run: nix develop -c ${{ matrix.task }}

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        task: [rainix-sol-test, rainix-sol-static, rainix-sol-artifacts]
+        task: [rainix-sol-test, rainix-sol-static]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
@@ -16,19 +16,29 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-
-      - uses: DeterminateSystems/nix-installer-action@v4
-      - uses: DeterminateSystems/magic-nix-cache-action@v2
-
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - uses: cachix/cachix-action@v15
+        continue-on-error: true
+        with:
+          name: rainlanguage
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          useDaemon: false
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
       - run: nix develop -c uniswap-prelude
-
       - run: nix develop -c rainix-sol-prelude
       - name: Run ${{ matrix.task }}
         env:
           ETH_RPC_URL: ${{ secrets.CI_DEPLOY_SEPOLIA_RPC_URL || vars.CI_DEPLOY_SEPOLIA_RPC_URL }}
           ETHERSCAN_API_KEY: ${{ secrets.EXPLORER_VERIFICATION_KEY }}
-          DEPLOY_BROADCAST: ''
-          DEPLOY_VERIFIER: ''
           DEPLOY_METABOARD_ADDRESS: ${{ vars.CI_DEPLOY_SEPOLIA_METABOARD_ADDRESS }}
           CI_FORK_SEPOLIA_BLOCK_NUMBER: ${{ vars.CI_FORK_SEPOLIA_BLOCK_NUMBER }}
           CI_FORK_SEPOLIA_DEPLOYER_ADDRESS: ${{ vars.CI_FORK_SEPOLIA_DEPLOYER_ADDRESS }}


### PR DESCRIPTION
Per project policy, deploy workflows must always sign with `secrets.PRIVATE_KEY`. Replaces the `github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV` conditional in: manual-sol-artifacts.yaml rainix.yaml